### PR TITLE
Feature/led status

### DIFF
--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -43,7 +43,6 @@ public:
             else
                 fill_charging(level);
         } else {
-            // fill(CRGB{CRGB::Black});
             fill(status_color);
         }
         FastLED.show();
@@ -89,7 +88,6 @@ private:
             percent = counter * 100 / thres;
         else
             percent = (thres * 2 - counter) * 100 / thres;
-        // CRGB color{CRGB::OrangeRed};
         CRGB color{status_color};
         for (auto &i : color.raw)
             i = i * percent / 100;
@@ -348,11 +346,11 @@ public:
         sw.poll();
         power.poll();
         auto sw_state{sw.get_state()};
-        if (sw_state == manual_switch::STATE::PUSHED){
+        if (sw_state == manual_switch::STATE::PUSHED) {
             power.set_manual_enable(true);
             Serial.println("Manual Charge");
         }
-        else if (sw_state == manual_switch::STATE::LONG_PUSHED){
+        else if (sw_state == manual_switch::STATE::LONG_PUSHED) {
             power.set_manual_enable(false);
             Serial.println("Auto Charge");
         }

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -42,8 +42,11 @@ public:
                 fill_breath();
             else
                 fill_charging(level);
+            
+            status_color = CRGB::GreenYellow; //https://lang-ship.com/blog/work/fastled/
         } else {
-            fill(CRGB{CRGB::Black});
+            // fill(CRGB{CRGB::Black});
+            fill(status_color);
         }
         FastLED.show();
         ++counter;
@@ -53,6 +56,10 @@ public:
             counter = 0;
         this->charging = enable;
         this->level = level;
+    }
+
+    void set_led_status(CRGB color) {
+        status_color = color;
     }
 private:
     void fill(const CRGB &color) {
@@ -91,6 +98,7 @@ private:
     }
     static constexpr uint32_t NUM_LEDS{45};
     CRGB led[NUM_LEDS];
+    CRGB status_color{CRGB::DodgerBlue};
     uint32_t counter{0};
     int32_t level{0};
     bool charging{false};
@@ -264,10 +272,12 @@ public:
             if (elapsed_ms > 10000) {
                 Serial.println("heartbeat timeout, stop charging.");
                 set_auto_enable(false);
+                led.set_led_status(CRGB::Orange);
             }
             if (terminal.is_overheat()) {
                 Serial.println("terminal overheat, stop charging.");
                 set_auto_enable(false);
+                led.set_led_status(CRGB::Red);
             }
         }
         if (relay.is_manual_mode()) {
@@ -275,6 +285,7 @@ public:
             if (elapsed_ms > 7200000) {
                 Serial.println("manual charging timeout, stop charging.");
                 set_manual_enable(false);
+                led.set_led_status(CRGB::HotPink);
             }
         }
     }


### PR DESCRIPTION
ChargerのLED表示を変更します。FastChargeから適用。24Hテストにて検証済み。

従来仕様
Idle時：消灯
充電時：オレンジ
電極オーバーヒート：LED表示なし
Heartbeatタイムアウト：LED表示なし
マニュアル充電 ２時間経過後オフ：LED表示なし

今回の仕様
Idle時：緑
充電時：オレンジ
電極オーバーヒート：赤
Heartbeatタイムアウト：青
マニュアル充電 ２時間経過後オフ：ピンク

電極オーバーヒート、Heartbeatタイムアウト、マニュアル充電 ２時間経過後オフの表示は次回の充電までステータスを保持し、充電が始まるとクリアされる

Change the LED display of the Charger, applicable from FastCharge.

Existing specification
Idle: Off
When charging: Orange
Error: Unlit

New specifications
Idle: Green
When charging: Orange
Electrode overheat: red
Heartbeat timeout: Blue
Manual charge Off after 2 hours: Pink

Electrode overheat, Heartbeat timeout, manual charge Off after 2 hours display holds status until next charge, clears when charge starts