### PR TITLE
LED color modification more simpler from v2.1.0

### DIFF
--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -269,12 +269,12 @@ public:
             if (elapsed_ms > 10000) {
                 Serial.println("heartbeat timeout, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
             if (terminal.is_overheat()) {
                 Serial.println("terminal overheat, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
         }
         if (relay.is_manual_mode()) {
@@ -282,7 +282,7 @@ public:
             if (elapsed_ms > 7200000) {
                 Serial.println("manual charging timeout, stop charging.");
                 set_manual_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
         }
     }
@@ -310,10 +310,11 @@ public:
         if (enable) {
             manual_charging_timer.reset();
             manual_charging_timer.start();
-            led.set_led_status(CRGB::Green);  //back to default color when enabled
+            led.set_led_status(CRGB::OrangeRed);  //back to default color when enabled
         } else {
             manual_charging_timer.stop();
             manual_charging_timer.reset();
+            led.set_led_status(CRGB::Green);  //back to default color when enabled
         }
     }
     bool get_auto_enable() const {

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -310,7 +310,7 @@ public:
         if (enable) {
             manual_charging_timer.reset();
             manual_charging_timer.start();
-            led.set_led_status(CRGB::OrangeRed);  //back to default color when enabled
+            led.set_led_status(CRGB::OrangeRed);
         } else {
             manual_charging_timer.stop();
             manual_charging_timer.reset();

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -269,12 +269,12 @@ public:
             if (elapsed_ms > 10000) {
                 Serial.println("heartbeat timeout, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Blue);
+                led.set_led_status(CRGB::Black);
             }
             if (terminal.is_overheat()) {
                 Serial.println("terminal overheat, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Red);
+                led.set_led_status(CRGB::Black);
             }
         }
         if (relay.is_manual_mode()) {
@@ -282,7 +282,7 @@ public:
             if (elapsed_ms > 7200000) {
                 Serial.println("manual charging timeout, stop charging.");
                 set_manual_enable(false);
-                led.set_led_status(CRGB::HotPink);
+                led.set_led_status(CRGB::Black);
             }
         }
     }


### PR DESCRIPTION
### motivation
v2.2.0 is released but we haven't ship to customer, because this release is created for internal debugging.
When the recent discussion we wanted to add one of the feature of v2.2.0 to customer site immediately.
This is the PR for kind of revert from V2.2.0 to V2.1.0

###  Changes
* Revert the color changes when these error occured, just keep default green color.
  * when auto charge connection time out occured
  * when manual charge time out occured
  * when over heat detected
* Revert the color when manual charging because this change on V2.2.0 seems caused by bug.

### No changes from V2.2.0 (Changes from V2.1.0)
* LED always lit to green for tell the status power is on.

### Test
Please see the video of the test result I posted on [Slack](https://lexxpluss.slack.com/archives/C04S3C5GVFF/p1749199092571029?thread_ts=1748927475.601919&cid=C04S3C5GVFF)

# Other
* Please merge before other PR from LED_color_industrial branch, it has dependensy *
