### PR TITLE
LED color changes to follow the industry standard

### DIFF
--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -1,27 +1,27 @@
 /*
- * Copyright (c) 2022, LexxPluss Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+   Copyright (c) 2022, LexxPluss Inc.
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+   ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #include <Arduino.h>
 #include <FastLED.h>
@@ -32,72 +32,98 @@
 namespace {
 
 class led_controller {
-public:
+  public:
+    const CRGB led_color_status_default = CRGB(12, 64, 8);
+    const CRGB led_color_status_default_dim = CRGB(6, 25, 3);
+    const CRGB led_color_auto_charging = CRGB(32, 128, 0);
+    const CRGB led_color_manual_charging = CRGB::OrangeRed;
+    const CRGB led_color_manual_charging_dim = CRGB(64, 15, 0);
+    const CRGB led_color_status_manual_charge_timeout = CRGB::HotPink;
+    const CRGB led_color_status_heartbeat_timeout = CRGB::Blue;
+    const CRGB led_color_status_terminal_overheat = CRGB::Red;
+
     void init() {
-        FastLED.addLeds<WS2812B, SPI_DATA, GRB>(led, NUM_LEDS);
+      FastLED.addLeds<WS2812B, SPI_DATA, GRB>(led, NUM_LEDS);
     }
     void poll() {
-        if (charging) {
-            if (level < 0)
-                //always fill_breath during the idle state of manual charege
-                fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
-            else
-                fill_charging(level);
-                last_autocharge_time_millis = millis();
-        } else {
-            int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
-            if( 0 <= t && t < 2000 ) {
-                // dim default LED color when immediately after from auto charge because of using same color.
-                if (t < 500){
-                    fill(CRGB::Black);
-                }
-                else {
-                    CRGB col_dim;
-                    CRGB col_def;
-                    for (int i = 0 ; i < 3 ; i ++){
-                        col_dim.raw[i] = led_color_default_dim.raw[i] * (t - 500) / 1500 ;
-                        col_def.raw[i] = led_color_default.raw[i] * (t - 500) / 1500 ;
-                    }
-                    fill(led_blink_crossfade(col_dim, col_def, 5000, 10, 40, 40, 0));
-                }
+      if (charging) {
+        if (level < 0)
+          //always fill_breath during the idle state of manual charege
+          fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
+        else
+          fill_charging(level);
+        last_autocharge_time_millis = millis();
+      } else { // display status
+        int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
+        if ( 0 <= t && t < 2000 ) {
+          // dim default LED color when immediately after from auto charge because of using same color.
+          if (t < 500) {
+            fill(CRGB::Black);
+          }
+          else {
+            CRGB col1_dim;
+            CRGB col2_dim;
+            for (int i = 0 ; i < 3 ; i ++) {
+              col1_dim.raw[i] = col1.raw[i] * (t - 500) / 1500 ;
+              col2_dim.raw[i] = col2.raw[i] * (t - 500) / 1500 ;
             }
-            else {
-                fill(led_blink_crossfade(led_color_default_dim, led_color_default, 5000, 10, 40, 40, 0));
-            }
+            fill(led_blink_crossfade(col1_dim, col2_dim, 5000, 10, 40, 40, 0));
+          }
         }
-        FastLED.show();
+        else {
+          fill(led_blink_crossfade(col1, col2, 5000, 10, 40, 40, 0));
+        }
+      }
+      FastLED.show();
     }
     void set_charging(bool enable, int32_t level = -1) {
-        this->charging = enable;
-        this->level = level;
-    }
-
-    void set_led_status(CRGB color) {
-        status_color = color;
+      this->charging = enable;
+      this->level = level;
     }
     
-    const CRGB led_color_default = CRGB(12,64,8);   
-    const CRGB led_color_default_dim = CRGB(6,25,3);   
-    const CRGB led_color_auto_charging = CRGB(32,128,0);
-    const CRGB led_color_manual_charging = CRGB::OrangeRed;
-    const CRGB led_color_manual_charging_dim = CRGB(64,15,0);
+    enum failure_status {
+      default_state = 0,
+      manual_charge_timeout,
+      heartbeat_timeout,
+      terminal_overheat
+    };
 
-private:
+    void set_led_status(failure_status s) {
+      if (s == manual_charge_timeout) {
+          col1 = led_color_status_default_dim;
+          col2 = led_color_status_default;
+      }
+      else if (s == heartbeat_timeout) {
+          col1 = led_color_status_default_dim;
+          col2 = led_color_status_default;
+      }
+      else if (s == terminal_overheat) {
+          col1 = CRGB::Red;
+          col2 = CRGB::Red;
+      }
+      else { //default
+          col1 = led_color_status_default_dim;
+          col2 = led_color_status_default;
+      }
+    }
+
+
+
+  private:
     void fill(const CRGB &color) {
-        for (auto &i : led)
-            i = color;
+      for (auto &i : led)
+        i = color;
     }
-    
-    void fill_charging(int32_t level) {
-        uint32_t n{(NUM_LEDS - 1) * level / 100U}; // The number of LED to express current battery remaining
 
+    void fill_charging(int32_t level) {
+        uint32_t n{(NUM_LEDS - 3) * level / 100U}; // The number of LED to express current battery remaining
+  
         //blinking tip
         static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
         for (uint32_t i{0}; i < NUM_LEDS; ++i) {
-            if( i < n )
-                led[NUM_LEDS - 1 - i] = led_color_auto_charging; //#FF4500, 100%,27%,0%
-            else if (i < n + blinking_tip_length){
-                //led[NUM_LEDS - 1 - i] = color_blinking;
+            if ( i < n )
+                led[NUM_LEDS - 1 - i] = led_color_auto_charging;
+            else if (i < n + blinking_tip_length) {
                 led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
             }
             else {
@@ -105,45 +131,46 @@ private:
             }
         }
     }
-    CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms){
-        /* 
-         * This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time. 
-         * If we set black to color1 and other color to color2, the return color will be blinked. 
-         * The return value is the CRGB color
-         * period : the cycle time for each blink [counts]
-         * duty_percent : The time ratio of fully lighting vs. cycle time[0 - 100 %]
-         * raising_percent : The time ratio of raising raising slope vs. cycle time[0 - 100 %]
-         * falling_percent : The time ratio of raising falling slope vs. cycle time[0 - 100 %]
-         * offset_ms
-         * (This function can't be controlled the origin state of the color, its fully depends on the time elapsed from start up)
-        */
-        uint32_t elapsed_ms{millis() % period_ms};
-  
-        // calc color ratio
-        uint32_t color_ratio_percent{0};
-        uint32_t time_ratio_permill{elapsed_ms * 1000U / period_ms};
-        if( time_ratio_permill < raising_percent * 10U ) {  // raising (brightening) phase
-            color_ratio_percent = time_ratio_permill * 10U / raising_percent;
-        }
-        else if ( time_ratio_permill < (raising_percent + lit_percent)*10U ){ // lit phase
-            color_ratio_percent = 100U;
-        }
-        else if ( time_ratio_permill < (raising_percent + lit_percent + falling_percent)*10U ){ // falling (dimming) phase
-            color_ratio_percent = ( (raising_percent + lit_percent + falling_percent ) * 10 - time_ratio_permill) * 10U / falling_percent;
-        }
-        else {
-            color_ratio_percent = 0U;
-        }
-        // blend the colors
-        CRGB ret{CRGB::Black};
-        for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
-            ret.raw[i] = ((int32_t)color2.raw[i] - (int32_t)color1.raw[i]) * (int32_t)color_ratio_percent / 100 + color1.raw[i];
-        }
-        return ret;
+    CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms) {
+      /*
+         This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time.
+         If we set black to color1 and other color to color2, the return color will be blinked.
+         The return value is the CRGB color
+         period : the cycle time for each blink [counts]
+         duty_percent : The time ratio of fully lighting vs. cycle time[0 - 100 %]
+         raising_percent : The time ratio of raising raising slope vs. cycle time[0 - 100 %]
+         falling_percent : The time ratio of raising falling slope vs. cycle time[0 - 100 %]
+         offset_ms
+         (This function can't be controlled the origin state of the color, its fully depends on the time elapsed from start up)
+      */
+      uint32_t elapsed_ms{millis() % period_ms};
+
+      // calc color ratio
+      uint32_t color_ratio_percent{0};
+      uint32_t time_ratio_permill{elapsed_ms * 1000U / period_ms};
+      if ( time_ratio_permill < raising_percent * 10U ) { // raising (brightening) phase
+        color_ratio_percent = time_ratio_permill * 10U / raising_percent;
+      }
+      else if ( time_ratio_permill < (raising_percent + lit_percent) * 10U ) { // lit phase
+        color_ratio_percent = 100U;
+      }
+      else if ( time_ratio_permill < (raising_percent + lit_percent + falling_percent) * 10U ) { // falling (dimming) phase
+        color_ratio_percent = ( (raising_percent + lit_percent + falling_percent ) * 10 - time_ratio_permill) * 10U / falling_percent;
+      }
+      else {
+        color_ratio_percent = 0U;
+      }
+      // blend the colors
+      CRGB ret{CRGB::Black};
+      for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
+        ret.raw[i] = ((int32_t)color2.raw[i] - (int32_t)color1.raw[i]) * (int32_t)color_ratio_percent / 100 + color1.raw[i];
+      }
+      return ret;
     }
     static constexpr uint32_t NUM_LEDS{45};
     CRGB led[NUM_LEDS];
-    CRGB status_color{led_color_default}; //Dark Green at startup
+    CRGB status_color{led_color_status_default};
+    CRGB col1{led_color_status_default_dim}, col2{led_color_status_default};
     int32_t level{0};
     int32_t dim_led_color_percent{0};
     unsigned long last_autocharge_time_millis{0};
@@ -152,227 +179,227 @@ private:
 
 
 class fan_controller {
-public:
-    void init() const{
-        pinMode(PIN_FAN, OUTPUT);
-        analogWrite(PIN_FAN, 0);
+  public:
+    void init() const {
+      pinMode(PIN_FAN, OUTPUT);
+      analogWrite(PIN_FAN, 0);
     }
     void poll() {
-        if(charging != prev)
-        {
-            if (charging) {
-                analogWrite(PIN_FAN, 255);
-            } else {
-                analogWrite(PIN_FAN, 0);
-            }       
+      if (charging != prev)
+      {
+        if (charging) {
+          analogWrite(PIN_FAN, 255);
+        } else {
+          analogWrite(PIN_FAN, 0);
         }
-        prev = charging;
+      }
+      prev = charging;
     }
     void set_charging(bool enable) {
-        this->charging = enable;
+      this->charging = enable;
     }
 
-private:
+  private:
     bool charging{false};
     static constexpr uint8_t PIN_FAN{4};
     bool prev{false};
 };
 
 class manual_switch {
-public:
+  public:
     enum class STATE {
-        RELEASED, PUSHED, LONG_PUSHED
+      RELEASED, PUSHED, LONG_PUSHED
     };
     void init() const {
-        pinMode(PIN_SW, INPUT);
-        pinMode(PIN_LED, OUTPUT);
-        digitalWrite(PIN_LED, 0);
+      pinMode(PIN_SW, INPUT);
+      pinMode(PIN_LED, OUTPUT);
+      digitalWrite(PIN_LED, 0);
     }
     void poll() {
-        STATE prev_state{state};
-        int now{digitalRead(PIN_SW)};
-        if (prev != now) {
-            Serial.print("power_switch change to ");
-            Serial.println(now);
-            prev = now;
-            timer.reset();
-            timer.start();
-        } else if (now == 0) {
-            auto elapsed_ms{timer.read_ms()};
-            if (elapsed_ms > 5000)
-                state = STATE::LONG_PUSHED;
-            else if (elapsed_ms > 500)
-                state = STATE::PUSHED;
-        } else if (now == 1) {
-            state = STATE::RELEASED;
+      STATE prev_state{state};
+      int now{digitalRead(PIN_SW)};
+      if (prev != now) {
+        Serial.print("power_switch change to ");
+        Serial.println(now);
+        prev = now;
+        timer.reset();
+        timer.start();
+      } else if (now == 0) {
+        auto elapsed_ms{timer.read_ms()};
+        if (elapsed_ms > 5000)
+          state = STATE::LONG_PUSHED;
+        else if (elapsed_ms > 500)
+          state = STATE::PUSHED;
+      } else if (now == 1) {
+        state = STATE::RELEASED;
+      }
+      if (prev_state != state) {
+        switch (state) {
+          case STATE::RELEASED:    Serial.println("switch state change to RELEASED"); break;
+          case STATE::PUSHED:      Serial.println("switch state change to PUSHED"); break;
+          case STATE::LONG_PUSHED: Serial.println("switch state change to LONG PUSHED"); break;
         }
-        if (prev_state != state) {
-            switch (state) {
-            case STATE::RELEASED:    Serial.println("switch state change to RELEASED"); break;
-            case STATE::PUSHED:      Serial.println("switch state change to PUSHED"); break;
-            case STATE::LONG_PUSHED: Serial.println("switch state change to LONG PUSHED"); break;
-            }
-        }
+      }
     }
-    STATE get_state() const {return state;}
+    STATE get_state() const {
+      return state;
+    }
     void set_led(bool enable) const {
-        digitalWrite(PIN_LED, enable ? 1 : 0);
+      digitalWrite(PIN_LED, enable ? 1 : 0);
     }
-private:
+  private:
     simpletimer timer;
     STATE state{STATE::RELEASED};
-    int prev{-1};
+    int prev{ -1};
     static constexpr uint8_t PIN_SW{16}, PIN_LED{17};
 };
 
 class power_terminal_individual {
-public:
+  public:
     power_terminal_individual(int pin) : pin(pin) {}
     void poll() {
-        int value{analogRead(pin)};
-        if (value <= 0)
-            value = 1;
-        else if (value >= 1024)
-            value = 1023;
-        // see https://lexxpluss.esa.io/posts/459
-        float adc_voltage{value * 5.0f / 1024.0f};
-        static constexpr float R0{3300.0f}, B{3970.0f}, T0{373.0f}, Rpu{10000.0f};
-        float R{Rpu * adc_voltage / (5.0f - adc_voltage)};
-        float T{1.0f / (logf(R / R0) / B + 1.0f / T0)};
-        temperature = T - 273.0f;
+      int value{analogRead(pin)};
+      if (value <= 0)
+        value = 1;
+      else if (value >= 1024)
+        value = 1023;
+      float adc_voltage{value * 5.0f / 1024.0f};
+      static constexpr float R0{3300.0f}, B{3970.0f}, T0{373.0f}, Rpu{10000.0f};
+      float R{Rpu * adc_voltage / (5.0f - adc_voltage)};
+      float T{1.0f / (logf(R / R0) / B + 1.0f / T0)};
+      temperature = T - 273.0f;
     }
     bool is_overheat() const {
-        return temperature > 80;
+      return temperature > 80;
     }
-private:
+  private:
     int pin, temperature{0};
 };
 
 class power_terminal {
-public:
+  public:
     void poll() {
-        terminal[0].poll();
-        terminal[1].poll();
+      terminal[0].poll();
+      terminal[1].poll();
     }
     bool is_overheat() const {
-        return terminal[0].is_overheat() || terminal[1].is_overheat();
+      return terminal[0].is_overheat() || terminal[1].is_overheat();
     }
-private:
-    power_terminal_individual terminal[2]{A0, A1};
+  private:
+    power_terminal_individual terminal[2] {A0, A1};
 };
 
 enum class CHARGING_MODE {
-    AUTO, MANUAL
+  AUTO, MANUAL
 };
 
 class relay_controller {
-public:
+  public:
     void init() {
-        pinMode(PIN_AC, OUTPUT);
-        digitalWrite(PIN_AC, 0);
-        pinMode(PIN_DC, OUTPUT);
-        digitalWrite(PIN_DC, 0);
+      pinMode(PIN_AC, OUTPUT);
+      digitalWrite(PIN_AC, 0);
+      pinMode(PIN_DC, OUTPUT);
+      digitalWrite(PIN_DC, 0);
     }
     void set_enable(bool enable, CHARGING_MODE mode = CHARGING_MODE::MANUAL) {
-        this->enable = enable;
-        this->mode = mode;
-        if (enable) {
-            if (mode == CHARGING_MODE::AUTO) {
-                digitalWrite(PIN_AC, 1);
-                digitalWrite(PIN_DC, 1);
-            } else {
-                digitalWrite(PIN_AC, 1);
-                digitalWrite(PIN_DC, 0);
-            }
+      this->enable = enable;
+      this->mode = mode;
+      if (enable) {
+        if (mode == CHARGING_MODE::AUTO) {
+          digitalWrite(PIN_AC, 1);
+          digitalWrite(PIN_DC, 1);
         } else {
-            digitalWrite(PIN_AC, 0);
-            digitalWrite(PIN_DC, 0);
+          digitalWrite(PIN_AC, 1);
+          digitalWrite(PIN_DC, 0);
         }
+      } else {
+        digitalWrite(PIN_AC, 0);
+        digitalWrite(PIN_DC, 0);
+      }
     }
     bool is_auto_mode() const {
-        return enable && mode == CHARGING_MODE::AUTO;
+      return enable && mode == CHARGING_MODE::AUTO;
     }
     bool is_manual_mode() const {
-        return enable && mode == CHARGING_MODE::MANUAL;
+      return enable && mode == CHARGING_MODE::MANUAL;
     }
-private:
+  private:
     CHARGING_MODE mode{CHARGING_MODE::MANUAL};
     bool enable{false};
     static constexpr uint8_t PIN_AC{13}, PIN_DC{14};
 };
 
 class power_controller {
-public:
+  public:
     void init() {
-        led.init();
-        relay.init();
-        fan.init();
-        heartbeat_timer.start();
+      led.init();
+      relay.init();
+      fan.init();
+      heartbeat_timer.start();
     }
     void poll() {
-        led.poll();
-        terminal.poll();
-        fan.poll();
-        if (relay.is_auto_mode()) {
-            auto elapsed_ms{heartbeat_timer.read_ms()};
-            if (elapsed_ms > 10000) {
-                Serial.println("heartbeat timeout, stop charging.");
-                set_auto_enable(false);
-                led.set_led_status(led.led_color_default);
-            }
-            if (terminal.is_overheat()) {
-                Serial.println("terminal overheat, stop charging.");
-                set_auto_enable(false);
-                led.set_led_status(CRGB::Red);
-            }
+      led.poll();
+      terminal.poll();
+      fan.poll();
+      if (relay.is_auto_mode()) {
+        auto elapsed_ms{heartbeat_timer.read_ms()};
+        if (elapsed_ms > 10000) {
+          Serial.println("heartbeat timeout, stop charging.");
+          set_auto_enable(false);
+          led.set_led_status(led_controller::failure_status::heartbeat_timeout);
         }
-        if (relay.is_manual_mode()) {
-            auto elapsed_ms{manual_charging_timer.read_ms()};
-            if (elapsed_ms > 7200000) {
-                Serial.println("manual charging timeout, stop charging.");
-                set_manual_enable(false);
-                led.set_led_status(led.led_color_default);
-            }
+        if (terminal.is_overheat()) {
+          Serial.println("terminal overheat, stop charging.");
+          set_auto_enable(false);
+          led.set_led_status(led_controller::failure_status::terminal_overheat);
         }
+      }
+      if (relay.is_manual_mode()) {
+        auto elapsed_ms{manual_charging_timer.read_ms()};
+        if (elapsed_ms > 7200000) {
+          Serial.println("manual charging timeout, stop charging.");
+          set_manual_enable(false);
+          led.set_led_status(led_controller::failure_status::manual_charge_timeout);
+        }
+      }
     }
     void ping() {
-        heartbeat_timer.reset();
+      heartbeat_timer.reset();
     }
     void set_auto_enable(bool enable, int32_t level = -1) {
-        if (!relay.is_manual_mode()) {
-            if (enable && !terminal.is_overheat()) {
-                relay.set_enable(true, CHARGING_MODE::AUTO);
-                led.set_charging(true, level);
-                fan.set_charging(true);
-                led.set_led_status(led.led_color_default);  //back to default color when enabled
-            } else {
-                relay.set_enable(false);
-                led.set_charging(false);
-                fan.set_charging(false);
-            }
+      if (!relay.is_manual_mode()) {
+        if (enable && !terminal.is_overheat()) {
+          relay.set_enable(true, CHARGING_MODE::AUTO);
+          led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
+          led.set_charging(true, level);
+          fan.set_charging(true);
+        } else {
+          relay.set_enable(false);
+          led.set_charging(false);
+          fan.set_charging(false);
         }
+      }
     }
     void set_manual_enable(bool enable) {
-        relay.set_enable(enable);
-        led.set_charging(enable);
-        fan.set_charging(enable);
-        if (enable) {
-            manual_charging_timer.reset();
-            manual_charging_timer.start();
-            led.set_led_status(led.led_color_default);  //back to default color when enabled
-        } else {
-            manual_charging_timer.stop();
-            manual_charging_timer.reset();
-            led.set_led_status(CRGB::Green);  //back to default color when enabled
-        }
+      relay.set_enable(enable);
+      led.set_charging(enable);
+      fan.set_charging(enable);
+      if (enable) {
+        manual_charging_timer.reset();
+        manual_charging_timer.start();
+        led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
+      } else {
+        manual_charging_timer.stop();
+        manual_charging_timer.reset();
+      }
     }
     bool get_auto_enable() const {
-        return relay.is_auto_mode();
+      return relay.is_auto_mode();
     }
     bool get_manual_enable() const {
-        return relay.is_manual_mode();
+      return relay.is_manual_mode();
     }
-private:
+  private:
     led_controller led;
     relay_controller relay;
     fan_controller fan;
@@ -381,64 +408,64 @@ private:
 };
 
 class charging_board {
-public:
+  public:
     void init() {
-        Serial.begin(115200, SERIAL_8N1);
-        Serial1.begin(4800, SERIAL_8N1);
-        pinMode(PIN_HB_LED, OUTPUT);
-        digitalWrite(PIN_HB_LED, 0);
-        sw.init();
-        power.init();
-        irda_timer.start();
-        heartbeat_led_timer.start();
+      Serial.begin(115200, SERIAL_8N1);
+      Serial1.begin(4800, SERIAL_8N1);
+      pinMode(PIN_HB_LED, OUTPUT);
+      digitalWrite(PIN_HB_LED, 0);
+      sw.init();
+      power.init();
+      irda_timer.start();
+      heartbeat_led_timer.start();
     }
     void poll() {
-        sw.poll();
-        power.poll();
-        auto sw_state{sw.get_state()};
-        if (sw_state == manual_switch::STATE::PUSHED) {
-            power.set_manual_enable(true);
-            Serial.println("Manual Charge");
+      sw.poll();
+      power.poll();
+      auto sw_state{sw.get_state()};
+      if (sw_state == manual_switch::STATE::PUSHED) {
+        power.set_manual_enable(true);
+        Serial.println("Manual Charge");
+      }
+      else if (sw_state == manual_switch::STATE::LONG_PUSHED) {
+        power.set_manual_enable(false);
+        Serial.println("Auto Charge");
+      }
+      sw.set_led(power.get_manual_enable());
+      while (Serial1.available()) {
+        if (irda_timer.read_ms() > 1000)
+          msg.reset();
+        irda_timer.reset();
+        int c{Serial1.read()};
+        if (msg.decode(c)) {
+          uint8_t param[3];
+          uint8_t command{msg.get_command(param)};
+          handle_command(command, param);
         }
-        else if (sw_state == manual_switch::STATE::LONG_PUSHED) {
-            power.set_manual_enable(false);
-            Serial.println("Auto Charge");
-        }
-        sw.set_led(power.get_manual_enable());
-        while (Serial1.available()) {
-            if (irda_timer.read_ms() > 1000)
-                msg.reset();
-            irda_timer.reset();
-            int c{Serial1.read()};
-            if (msg.decode(c)) {
-                uint8_t param[3];
-                uint8_t command{msg.get_command(param)};
-                handle_command(command, param);
-            }
-        }
-        if (heartbeat_led_timer.read_ms() > 1000) {
-            heartbeat_led_timer.reset();
-            heartbeat_led = !heartbeat_led;
-            digitalWrite(PIN_HB_LED, heartbeat_led ? 1 : 0);
-        }
-        delay(30);
+      }
+      if (heartbeat_led_timer.read_ms() > 1000) {
+        heartbeat_led_timer.reset();
+        heartbeat_led = !heartbeat_led;
+        digitalWrite(PIN_HB_LED, heartbeat_led ? 1 : 0);
+      }
+      delay(30);
     }
-private:
+  private:
     void handle_command(uint8_t command, uint8_t (&param)[3]) {
-        switch (command) {
+      switch (command) {
         case serial_message::HEARTBEAT:
-            heartbeat(param);
-            break;
+          heartbeat(param);
+          break;
         default:
-            break;
-        }
+          break;
+      }
     }
     void heartbeat(const uint8_t (&param)[3]) {
-        power.set_auto_enable(param[1] != 0, param[2]);
-        uint8_t buf[8], send_param[3]{param[0], power.get_auto_enable()};
-        serial_message::compose(buf, serial_message::HEARTBEAT, send_param);
-        Serial1.write(buf, sizeof buf);
-        power.ping();
+      power.set_auto_enable(param[1] != 0, param[2]);
+      uint8_t buf[8], send_param[3] {param[0], power.get_auto_enable()};
+      serial_message::compose(buf, serial_message::HEARTBEAT, send_param);
+      Serial1.write(buf, sizeof buf);
+      power.ping();
     }
     manual_switch sw;
     power_controller power;
@@ -454,12 +481,12 @@ namespace lexxpluss {
 
 void setup()
 {
-    impl.init();
+  impl.init();
 }
 
 void loop()
 {
-    impl.poll();
+  impl.poll();
 }
 
 }

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -39,18 +39,15 @@ public:
     void poll() {
         if (charging) {
             if (level < 0)
-                //fill_breath();
                 //always fill_breath during the idle state of manual charege
                 fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
             else
                 fill_charging(level);
                 last_autocharge_time_millis = millis();
         } else {
-//            fill(status_color);
             int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
             if( 0 <= t && t < 2000 ) {
                 // dim default LED color when immediately after from auto charge because of using same color.
-
                 if (t < 500){
                     fill(CRGB::Black);
                 }
@@ -61,21 +58,6 @@ public:
                         col_dim.raw[i] = led_color_default_dim.raw[i] * (t - 500) / 1500 ;
                         col_def.raw[i] = led_color_default.raw[i] * (t - 500) / 1500 ;
                     }
-//
-//                    Serial.print("col_dim: ");
-//                    Serial.print(col_dim.raw[0]);
-//                    Serial.print(", ");
-//                    Serial.print(col_dim.raw[1]);
-//                    Serial.print(", ");
-//                    Serial.print(col_dim.raw[2]);
-//                    Serial.print("    col_def: ");
-//                    Serial.print(col_def.raw[0]);
-//                    Serial.print(", ");
-//                    Serial.print(col_def.raw[1]);
-//                    Serial.print(", ");
-//                    Serial.print(col_def.raw[2]);
-//                    Serial.println(". ");
-                    
                     fill(led_blink_crossfade(col_dim, col_def, 5000, 10, 40, 40, 0));
                 }
             }
@@ -84,11 +66,8 @@ public:
             }
         }
         FastLED.show();
-//        ++counter;
     }
     void set_charging(bool enable, int32_t level = -1) {
-//        if (!this->charging && enable)
-//            counter = 0;
         this->charging = enable;
         this->level = level;
     }
@@ -110,41 +89,10 @@ private:
     }
     
     void fill_charging(int32_t level) {
-//        static constexpr uint32_t blink_cycle_period{80}, 
-//        blink_raising_period{15}, blink_lighting_period{25}, blink_falling_period{15} ;
-
-//        if (counter >= blink_cycle_period)
-//            counter = 0;
-
-        //static const CRGB color{CRGB::OrangeRed}, black{CRGB::Black};
         uint32_t n{(NUM_LEDS - 1) * level / 100U}; // The number of LED to express current battery remaining
 
         //blinking tip
         static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
-//        CRGB color_blinking{CRGB::Black};
-//        uint32_t dim_percent{50};
-
-
-
-        
-//        if(counter < blink_raising_period) {
-//            dim_percent = counter * 100U / blink_raising_period;
-//            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
-//        }
-//        else if(counter < blink_raising_period + blink_lighting_period) {
-//            color_blinking = led_color_auto_charging;
-//        }
-//        else if(counter < blink_raising_period + blink_lighting_period + blink_falling_period) {
-//            dim_percent = ( (blink_raising_period + blink_lighting_period + blink_falling_period - counter) * 100U) / blink_falling_period;
-//            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
-//        }
-//        else {
-//            color_blinking = CRGB::Black;
-//        }
-
-
-
-        
         for (uint32_t i{0}; i < NUM_LEDS; ++i) {
             if( i < n )
                 led[NUM_LEDS - 1 - i] = led_color_auto_charging; //#FF4500, 100%,27%,0%
@@ -157,20 +105,6 @@ private:
             }
         }
     }
-//    void fill_breath() {
-//        static constexpr uint32_t thres{60};
-//        if (counter >= thres * 2)
-//            counter = 0;
-//        uint32_t percent;
-//        if (counter < thres)
-//            percent = counter * 100 / thres;
-//        else
-//            percent = (thres * 2 - counter) * 100 / thres;
-//        CRGB color{status_color};
-//        for (auto &i : color.raw)
-//            i = i * percent / 100;
-//        fill(color);
-//    }
     CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms){
         /* 
          * This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time. 
@@ -200,10 +134,6 @@ private:
         else {
             color_ratio_percent = 0U;
         }
-//        Serial.print(time_ratio_permill);
-//        Serial.print(", ");
-//        Serial.println(color_ratio_percent);
-        
         // blend the colors
         CRGB ret{CRGB::Black};
         for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
@@ -214,7 +144,6 @@ private:
     static constexpr uint32_t NUM_LEDS{45};
     CRGB led[NUM_LEDS];
     CRGB status_color{led_color_default}; //Dark Green at startup
-//    uint32_t counter{0};
     int32_t level{0};
     int32_t dim_led_color_percent{0};
     unsigned long last_autocharge_time_millis{0};

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -269,12 +269,12 @@ public:
             if (elapsed_ms > 10000) {
                 Serial.println("heartbeat timeout, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
             if (terminal.is_overheat()) {
                 Serial.println("terminal overheat, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
         }
         if (relay.is_manual_mode()) {
@@ -282,7 +282,7 @@ public:
             if (elapsed_ms > 7200000) {
                 Serial.println("manual charging timeout, stop charging.");
                 set_manual_enable(false);
-                led.set_led_status(CRGB::Black);
+                led.set_led_status(CRGB::Green);
             }
         }
     }
@@ -310,10 +310,11 @@ public:
         if (enable) {
             manual_charging_timer.reset();
             manual_charging_timer.start();
-            led.set_led_status(CRGB::Green);  //back to default color when enabled
+            led.set_led_status(CRGB::OrangeRed);  //back to default color when enabled
         } else {
             manual_charging_timer.stop();
             manual_charging_timer.reset();
+            led.set_led_status(CRGB::Green);  //back to default color when enabled
         }
     }
     bool get_auto_enable() const {

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -310,7 +310,7 @@ public:
         if (enable) {
             manual_charging_timer.reset();
             manual_charging_timer.start();
-            led.set_led_status(CRGB::OrangeRed);  //back to default color when enabled
+            led.set_led_status(CRGB::OrangeRed);
         } else {
             manual_charging_timer.stop();
             manual_charging_timer.reset();

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -80,7 +80,7 @@ class led_controller {
       this->charging = enable;
       this->level = level;
     }
-    
+
     enum failure_status {
       default_state = 0,
       manual_charge_timeout,
@@ -90,20 +90,20 @@ class led_controller {
 
     void set_led_status(failure_status s) {
       if (s == manual_charge_timeout) {
-          col1 = led_color_status_default_dim;
-          col2 = led_color_status_default;
+        col1 = led_color_status_default_dim;
+        col2 = led_color_status_default;
       }
       else if (s == heartbeat_timeout) {
-          col1 = led_color_status_default_dim;
-          col2 = led_color_status_default;
+        col1 = led_color_status_default_dim;
+        col2 = led_color_status_default;
       }
       else if (s == terminal_overheat) {
-          col1 = CRGB::Red;
-          col2 = CRGB::Red;
+        col1 = CRGB::Red;
+        col2 = CRGB::Red;
       }
       else { //default
-          col1 = led_color_status_default_dim;
-          col2 = led_color_status_default;
+        col1 = led_color_status_default_dim;
+        col2 = led_color_status_default;
       }
     }
 
@@ -116,20 +116,20 @@ class led_controller {
     }
 
     void fill_charging(int32_t level) {
-        uint32_t n{(NUM_LEDS - 3) * level / 100U}; // The number of LED to express current battery remaining
-  
-        //blinking tip
-        static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
-        for (uint32_t i{0}; i < NUM_LEDS; ++i) {
-            if ( i < n )
-                led[NUM_LEDS - 1 - i] = led_color_auto_charging;
-            else if (i < n + blinking_tip_length) {
-                led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
-            }
-            else {
-                led[NUM_LEDS - 1 - i] = CRGB::Black;
-            }
+      uint32_t n{(NUM_LEDS - 3) * level / 100U}; // The number of LED to express current battery remaining
+
+      //blinking tip
+      static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
+      for (uint32_t i{0}; i < NUM_LEDS; ++i) {
+        if ( i < n )
+          led[NUM_LEDS - 1 - i] = led_color_auto_charging;
+        else if (i < n + blinking_tip_length) {
+          led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
         }
+        else {
+          led[NUM_LEDS - 1 - i] = CRGB::Black;
+        }
+      }
     }
     CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms) {
       /*

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -1,27 +1,27 @@
 /*
-   Copyright (c) 2022, LexxPluss Inc.
-   All rights reserved.
-
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-   2. Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-   ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2022, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <Arduino.h>
 #include <FastLED.h>
@@ -32,7 +32,7 @@
 namespace {
 
 class led_controller {
-  public:
+public:
     const CRGB led_color_status_default = CRGB(12, 64, 8);
     const CRGB led_color_status_default_dim = CRGB(6, 25, 3);
     const CRGB led_color_auto_charging = CRGB(32, 128, 0);
@@ -42,131 +42,132 @@ class led_controller {
     const CRGB led_color_status_heartbeat_timeout = CRGB::Blue;
     const CRGB led_color_status_terminal_overheat = CRGB::Red;
 
-    void init() {
-      FastLED.addLeds<WS2812B, SPI_DATA, GRB>(led, NUM_LEDS);
-    }
-    void poll() {
-      if (charging) {
-        if (level < 0)
-          //always fill_breath during the idle state of manual charege
-          fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
-        else
-          fill_charging(level);
-        last_autocharge_time_millis = millis();
-      } else { // display status
-        int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
-        if ( 0 <= t && t < 2000 ) {
-          // dim default LED color when immediately after from auto charge because of using same color.
-          if (t < 500) {
-            fill(CRGB::Black);
-          }
-          else {
-            CRGB col1_dim;
-            CRGB col2_dim;
-            for (int i = 0 ; i < 3 ; i ++) {
-              col1_dim.raw[i] = col1.raw[i] * (t - 500) / 1500 ;
-              col2_dim.raw[i] = col2.raw[i] * (t - 500) / 1500 ;
-            }
-            fill(led_blink_crossfade(col1_dim, col2_dim, 5000, 10, 40, 40, 0));
-          }
-        }
-        else {
-          fill(led_blink_crossfade(col1, col2, 5000, 10, 40, 40, 0));
-        }
-      }
-      FastLED.show();
-    }
-    void set_charging(bool enable, int32_t level = -1) {
-      this->charging = enable;
-      this->level = level;
-    }
-
     enum failure_status {
-      default_state = 0,
-      manual_charge_timeout,
-      heartbeat_timeout,
-      terminal_overheat
+        default_state = 0,
+        manual_charge_timeout,
+        heartbeat_timeout,
+        terminal_overheat
     };
 
+    void init() {
+        FastLED.addLeds<WS2812B, SPI_DATA, GRB>(led, NUM_LEDS);
+    }
+    void poll() {
+        if (charging) {
+            if (level < 0)
+                //always fill_breath during the idle state of manual charege
+                fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
+            else {
+                fill_charging(level);
+                last_autocharge_time_millis = millis();
+            }
+        } else {
+            int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
+            if( 0 <= t && t < 2000 ) {
+                // dim default LED color when immediately after from auto charge because of using same color.
+                if (t < 500){
+                    fill(CRGB::Black);
+                }
+                else {
+                    CRGB col1_dim;
+                    CRGB col2_dim;
+                    for (int i = 0 ; i < 3 ; i ++){
+                        col1_dim.raw[i] = col1.raw[i] * (t - 500) / 1500 ;
+                        col2_dim.raw[i] = col2.raw[i] * (t - 500) / 1500 ;
+                    }
+                    fill(led_blink_crossfade(col1_dim, col2_dim, 5000, 10, 40, 40, 0));
+                }
+            }
+            else {
+                fill(led_blink_crossfade(col1, col2, 5000, 10, 40, 40, 0));
+            }
+        }
+        FastLED.show();
+    }
+    void set_charging(bool enable, int32_t level = -1) {
+        this->charging = enable;
+        this->level = level;
+    }
+
     void set_led_status(failure_status s) {
-      if (s == manual_charge_timeout) {
-        col1 = led_color_status_default_dim;
-        col2 = led_color_status_default;
-      }
-      else if (s == heartbeat_timeout) {
-        col1 = led_color_status_default_dim;
-        col2 = led_color_status_default;
-      }
-      else if (s == terminal_overheat) {
-        col1 = CRGB::Red;
-        col2 = CRGB::Red;
-      }
-      else { //default
-        col1 = led_color_status_default_dim;
-        col2 = led_color_status_default;
-      }
+        if (s == manual_charge_timeout) {
+            col1 = led_color_status_default_dim;
+            col2 = led_color_status_default;
+        }
+        else if (s == heartbeat_timeout) {
+            col1 = led_color_status_default_dim;
+            col2 = led_color_status_default;
+        }
+        else if (s == terminal_overheat) {
+            col1 = CRGB::Red;
+            col2 = CRGB::Red;
+        }
+        else { //default
+            col1 = led_color_status_default_dim;
+            col2 = led_color_status_default;
+        }
     }
 
-
-
-  private:
+private:
     void fill(const CRGB &color) {
-      for (auto &i : led)
-        i = color;
+        for (auto &i : led)
+            i = color;
     }
-
+    
     void fill_charging(int32_t level) {
-      uint32_t n{(NUM_LEDS - 3) * level / 100U}; // The number of LED to express current battery remaining
+        uint32_t n{(NUM_LEDS - 3) * level / 100U}; // The number of LED to express current battery 
 
-      //blinking tip
-      static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
-      for (uint32_t i{0}; i < NUM_LEDS; ++i) {
-        if ( i < n )
-          led[NUM_LEDS - 1 - i] = led_color_auto_charging;
-        else if (i < n + blinking_tip_length) {
-          led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
+        //blinking tip
+        static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
+        for (uint32_t i{0}; i < NUM_LEDS; ++i) {
+            if( i < n )
+                led[NUM_LEDS - 1 - i] = led_color_auto_charging;
+            else if (i < n + blinking_tip_length){
+                led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
+            }
+            else {
+                led[NUM_LEDS - 1 - i] = CRGB::Black;
+            }
+        }
+    }
+    CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms){
+        /* 
+         * This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time. 
+         * If we set black to color1 and other color to color2, the return color will be blinked. 
+         * The return value is the CRGB color
+         * period : the cycle time for each blink [counts]
+         * duty_percent : The time ratio of fully lighting vs. cycle time[0 - 100 %]
+         * raising_percent : The time ratio of raising raising slope vs. cycle time[0 - 100 %]
+         * falling_percent : The time ratio of raising falling slope vs. cycle time[0 - 100 %]
+         * offset_ms
+         * (This function can't be controlled the origin state of the color, its fully depends on the time elapsed from start up)
+        */
+        uint32_t elapsed_ms{millis() % period_ms};
+  
+        // calc color ratio
+        uint32_t color_ratio_percent{0};
+        uint32_t time_ratio_permill{elapsed_ms * 1000U / period_ms};
+        if( time_ratio_permill < raising_percent * 10U ) {  // raising (brightening) phase
+            color_ratio_percent = time_ratio_permill * 10U / raising_percent;
+        }
+        else if ( time_ratio_permill < (raising_percent + lit_percent)*10U ){ // lit phase
+            color_ratio_percent = 100U;
+        }
+        else if ( time_ratio_permill < (raising_percent + lit_percent + falling_percent)*10U ){ // falling (dimming) phase
+            color_ratio_percent = ( (raising_percent + lit_percent + falling_percent ) * 10 - time_ratio_permill) * 10U / falling_percent;
         }
         else {
-          led[NUM_LEDS - 1 - i] = CRGB::Black;
+            color_ratio_percent = 0U;
         }
-      }
+        // blend the colors
+        CRGB ret{CRGB::Black};
+        for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
+            ret.raw[i] = ((int32_t)color2.raw[i] - (int32_t)color1.raw[i]) * (int32_t)color_ratio_percent / 100 + color1.raw[i];
+        }
+        return ret;
     }
-    CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms) {
-      /*
-         This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time.
-         If we set black to color1 and other color to color2, the return color will be blinked.
-         The return value is the CRGB color
-         period : the cycle time for each blink [counts]
-         duty_percent : The time ratio of fully lighting vs. cycle time[0 - 100 %]
-         raising_percent : The time ratio of raising raising slope vs. cycle time[0 - 100 %]
-         falling_percent : The time ratio of raising falling slope vs. cycle time[0 - 100 %]
-         offset_ms
-         (This function can't be controlled the origin state of the color, its fully depends on the time elapsed from start up)
-      */
-      uint32_t elapsed_ms{millis() % period_ms};
 
-      // calc color ratio
-      uint32_t color_ratio_percent{0};
-      uint32_t time_ratio_permill{elapsed_ms * 1000U / period_ms};
-      if ( time_ratio_permill < raising_percent * 10U ) { // raising (brightening) phase
-        color_ratio_percent = time_ratio_permill * 10U / raising_percent;
-      }
-      else if ( time_ratio_permill < (raising_percent + lit_percent) * 10U ) { // lit phase
-        color_ratio_percent = 100U;
-      }
-      else if ( time_ratio_permill < (raising_percent + lit_percent + falling_percent) * 10U ) { // falling (dimming) phase
-        color_ratio_percent = ( (raising_percent + lit_percent + falling_percent ) * 10 - time_ratio_permill) * 10U / falling_percent;
-      }
-      else {
-        color_ratio_percent = 0U;
-      }
-      // blend the colors
-      CRGB ret{CRGB::Black};
-      for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
-        ret.raw[i] = ((int32_t)color2.raw[i] - (int32_t)color1.raw[i]) * (int32_t)color_ratio_percent / 100 + color1.raw[i];
-      }
-      return ret;
-    }
+    
     static constexpr uint32_t NUM_LEDS{45};
     CRGB led[NUM_LEDS];
     CRGB status_color{led_color_status_default};
@@ -179,227 +180,226 @@ class led_controller {
 
 
 class fan_controller {
-  public:
-    void init() const {
-      pinMode(PIN_FAN, OUTPUT);
-      analogWrite(PIN_FAN, 0);
+public:
+    void init() const{
+        pinMode(PIN_FAN, OUTPUT);
+        analogWrite(PIN_FAN, 0);
     }
     void poll() {
-      if (charging != prev)
-      {
-        if (charging) {
-          analogWrite(PIN_FAN, 255);
-        } else {
-          analogWrite(PIN_FAN, 0);
+        if(charging != prev)
+        {
+            if (charging) {
+                analogWrite(PIN_FAN, 255);
+            } else {
+                analogWrite(PIN_FAN, 0);
+            }       
         }
-      }
-      prev = charging;
+        prev = charging;
     }
     void set_charging(bool enable) {
-      this->charging = enable;
+        this->charging = enable;
     }
 
-  private:
+private:
     bool charging{false};
     static constexpr uint8_t PIN_FAN{4};
     bool prev{false};
 };
 
 class manual_switch {
-  public:
+public:
     enum class STATE {
-      RELEASED, PUSHED, LONG_PUSHED
+        RELEASED, PUSHED, LONG_PUSHED
     };
     void init() const {
-      pinMode(PIN_SW, INPUT);
-      pinMode(PIN_LED, OUTPUT);
-      digitalWrite(PIN_LED, 0);
+        pinMode(PIN_SW, INPUT);
+        pinMode(PIN_LED, OUTPUT);
+        digitalWrite(PIN_LED, 0);
     }
     void poll() {
-      STATE prev_state{state};
-      int now{digitalRead(PIN_SW)};
-      if (prev != now) {
-        Serial.print("power_switch change to ");
-        Serial.println(now);
-        prev = now;
-        timer.reset();
-        timer.start();
-      } else if (now == 0) {
-        auto elapsed_ms{timer.read_ms()};
-        if (elapsed_ms > 5000)
-          state = STATE::LONG_PUSHED;
-        else if (elapsed_ms > 500)
-          state = STATE::PUSHED;
-      } else if (now == 1) {
-        state = STATE::RELEASED;
-      }
-      if (prev_state != state) {
-        switch (state) {
-          case STATE::RELEASED:    Serial.println("switch state change to RELEASED"); break;
-          case STATE::PUSHED:      Serial.println("switch state change to PUSHED"); break;
-          case STATE::LONG_PUSHED: Serial.println("switch state change to LONG PUSHED"); break;
+        STATE prev_state{state};
+        int now{digitalRead(PIN_SW)};
+        if (prev != now) {
+            Serial.print("power_switch change to ");
+            Serial.println(now);
+            prev = now;
+            timer.reset();
+            timer.start();
+        } else if (now == 0) {
+            auto elapsed_ms{timer.read_ms()};
+            if (elapsed_ms > 5000)
+                state = STATE::LONG_PUSHED;
+            else if (elapsed_ms > 500)
+                state = STATE::PUSHED;
+        } else if (now == 1) {
+            state = STATE::RELEASED;
         }
-      }
+        if (prev_state != state) {
+            switch (state) {
+            case STATE::RELEASED:    Serial.println("switch state change to RELEASED"); break;
+            case STATE::PUSHED:      Serial.println("switch state change to PUSHED"); break;
+            case STATE::LONG_PUSHED: Serial.println("switch state change to LONG PUSHED"); break;
+            }
+        }
     }
-    STATE get_state() const {
-      return state;
-    }
+    STATE get_state() const {return state;}
     void set_led(bool enable) const {
-      digitalWrite(PIN_LED, enable ? 1 : 0);
+        digitalWrite(PIN_LED, enable ? 1 : 0);
     }
-  private:
+private:
     simpletimer timer;
     STATE state{STATE::RELEASED};
-    int prev{ -1};
+    int prev{-1};
     static constexpr uint8_t PIN_SW{16}, PIN_LED{17};
 };
 
 class power_terminal_individual {
-  public:
+public:
     power_terminal_individual(int pin) : pin(pin) {}
     void poll() {
-      int value{analogRead(pin)};
-      if (value <= 0)
-        value = 1;
-      else if (value >= 1024)
-        value = 1023;
-      float adc_voltage{value * 5.0f / 1024.0f};
-      static constexpr float R0{3300.0f}, B{3970.0f}, T0{373.0f}, Rpu{10000.0f};
-      float R{Rpu * adc_voltage / (5.0f - adc_voltage)};
-      float T{1.0f / (logf(R / R0) / B + 1.0f / T0)};
-      temperature = T - 273.0f;
+        int value{analogRead(pin)};
+        if (value <= 0)
+            value = 1;
+        else if (value >= 1024)
+            value = 1023;
+        // see https://lexxpluss.esa.io/posts/459
+        float adc_voltage{value * 5.0f / 1024.0f};
+        static constexpr float R0{3300.0f}, B{3970.0f}, T0{373.0f}, Rpu{10000.0f};
+        float R{Rpu * adc_voltage / (5.0f - adc_voltage)};
+        float T{1.0f / (logf(R / R0) / B + 1.0f / T0)};
+        temperature = T - 273.0f;
     }
     bool is_overheat() const {
-      return temperature > 80;
+        return temperature > 80;
     }
-  private:
+private:
     int pin, temperature{0};
 };
 
 class power_terminal {
-  public:
+public:
     void poll() {
-      terminal[0].poll();
-      terminal[1].poll();
+        terminal[0].poll();
+        terminal[1].poll();
     }
     bool is_overheat() const {
-      return terminal[0].is_overheat() || terminal[1].is_overheat();
+        return terminal[0].is_overheat() || terminal[1].is_overheat();
     }
-  private:
-    power_terminal_individual terminal[2] {A0, A1};
+private:
+    power_terminal_individual terminal[2]{A0, A1};
 };
 
 enum class CHARGING_MODE {
-  AUTO, MANUAL
+    AUTO, MANUAL
 };
 
 class relay_controller {
-  public:
+public:
     void init() {
-      pinMode(PIN_AC, OUTPUT);
-      digitalWrite(PIN_AC, 0);
-      pinMode(PIN_DC, OUTPUT);
-      digitalWrite(PIN_DC, 0);
+        pinMode(PIN_AC, OUTPUT);
+        digitalWrite(PIN_AC, 0);
+        pinMode(PIN_DC, OUTPUT);
+        digitalWrite(PIN_DC, 0);
     }
     void set_enable(bool enable, CHARGING_MODE mode = CHARGING_MODE::MANUAL) {
-      this->enable = enable;
-      this->mode = mode;
-      if (enable) {
-        if (mode == CHARGING_MODE::AUTO) {
-          digitalWrite(PIN_AC, 1);
-          digitalWrite(PIN_DC, 1);
+        this->enable = enable;
+        this->mode = mode;
+        if (enable) {
+            if (mode == CHARGING_MODE::AUTO) {
+                digitalWrite(PIN_AC, 1);
+                digitalWrite(PIN_DC, 1);
+            } else {
+                digitalWrite(PIN_AC, 1);
+                digitalWrite(PIN_DC, 0);
+            }
         } else {
-          digitalWrite(PIN_AC, 1);
-          digitalWrite(PIN_DC, 0);
+            digitalWrite(PIN_AC, 0);
+            digitalWrite(PIN_DC, 0);
         }
-      } else {
-        digitalWrite(PIN_AC, 0);
-        digitalWrite(PIN_DC, 0);
-      }
     }
     bool is_auto_mode() const {
-      return enable && mode == CHARGING_MODE::AUTO;
+        return enable && mode == CHARGING_MODE::AUTO;
     }
     bool is_manual_mode() const {
-      return enable && mode == CHARGING_MODE::MANUAL;
+        return enable && mode == CHARGING_MODE::MANUAL;
     }
-  private:
+private:
     CHARGING_MODE mode{CHARGING_MODE::MANUAL};
     bool enable{false};
     static constexpr uint8_t PIN_AC{13}, PIN_DC{14};
 };
 
 class power_controller {
-  public:
+public:
     void init() {
-      led.init();
-      relay.init();
-      fan.init();
-      heartbeat_timer.start();
+        led.init();
+        relay.init();
+        fan.init();
+        heartbeat_timer.start();
     }
     void poll() {
-      led.poll();
-      terminal.poll();
-      fan.poll();
-      if (relay.is_auto_mode()) {
-        auto elapsed_ms{heartbeat_timer.read_ms()};
-        if (elapsed_ms > 10000) {
-          Serial.println("heartbeat timeout, stop charging.");
-          set_auto_enable(false);
-          led.set_led_status(led_controller::failure_status::heartbeat_timeout);
+        led.poll();
+        terminal.poll();
+        fan.poll();
+        if (relay.is_auto_mode()) {
+            auto elapsed_ms{heartbeat_timer.read_ms()};
+            if (elapsed_ms > 10000) {
+                Serial.println("heartbeat timeout, stop charging.");
+                set_auto_enable(false);
+                led.set_led_status(led_controller::failure_status::heartbeat_timeout);
+            }
+            if (terminal.is_overheat()) {
+                Serial.println("terminal overheat, stop charging.");
+                set_auto_enable(false);
+                led.set_led_status(led_controller::failure_status::terminal_overheat);
+            }
         }
-        if (terminal.is_overheat()) {
-          Serial.println("terminal overheat, stop charging.");
-          set_auto_enable(false);
-          led.set_led_status(led_controller::failure_status::terminal_overheat);
+        if (relay.is_manual_mode()) {
+            auto elapsed_ms{manual_charging_timer.read_ms()};
+            if (elapsed_ms > 7200000) {
+                Serial.println("manual charging timeout, stop charging.");
+                set_manual_enable(false);
+                led.set_led_status(led_controller::failure_status::manual_charge_timeout);
+            }
         }
-      }
-      if (relay.is_manual_mode()) {
-        auto elapsed_ms{manual_charging_timer.read_ms()};
-        if (elapsed_ms > 7200000) {
-          Serial.println("manual charging timeout, stop charging.");
-          set_manual_enable(false);
-          led.set_led_status(led_controller::failure_status::manual_charge_timeout);
-        }
-      }
     }
     void ping() {
-      heartbeat_timer.reset();
+        heartbeat_timer.reset();
     }
     void set_auto_enable(bool enable, int32_t level = -1) {
-      if (!relay.is_manual_mode()) {
-        if (enable && !terminal.is_overheat()) {
-          relay.set_enable(true, CHARGING_MODE::AUTO);
-          led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
-          led.set_charging(true, level);
-          fan.set_charging(true);
-        } else {
-          relay.set_enable(false);
-          led.set_charging(false);
-          fan.set_charging(false);
+        if (!relay.is_manual_mode()) {
+            if (enable && !terminal.is_overheat()) {
+                relay.set_enable(true, CHARGING_MODE::AUTO);
+                led.set_charging(true, level);
+                fan.set_charging(true);
+                led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
+            } else {
+                relay.set_enable(false);
+                led.set_charging(false);
+                fan.set_charging(false);
+            }
         }
-      }
     }
     void set_manual_enable(bool enable) {
-      relay.set_enable(enable);
-      led.set_charging(enable);
-      fan.set_charging(enable);
-      if (enable) {
-        manual_charging_timer.reset();
-        manual_charging_timer.start();
-        led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
-      } else {
-        manual_charging_timer.stop();
-        manual_charging_timer.reset();
-      }
+        relay.set_enable(enable);
+        led.set_charging(enable);
+        fan.set_charging(enable);
+        if (enable) {
+            manual_charging_timer.reset();
+            manual_charging_timer.start();
+            led.set_led_status(led_controller::failure_status::default_state);  //back to default color when enabled
+        } else {
+            manual_charging_timer.stop();
+            manual_charging_timer.reset();
+        }
     }
     bool get_auto_enable() const {
-      return relay.is_auto_mode();
+        return relay.is_auto_mode();
     }
     bool get_manual_enable() const {
-      return relay.is_manual_mode();
+        return relay.is_manual_mode();
     }
-  private:
+private:
     led_controller led;
     relay_controller relay;
     fan_controller fan;
@@ -408,64 +408,64 @@ class power_controller {
 };
 
 class charging_board {
-  public:
+public:
     void init() {
-      Serial.begin(115200, SERIAL_8N1);
-      Serial1.begin(4800, SERIAL_8N1);
-      pinMode(PIN_HB_LED, OUTPUT);
-      digitalWrite(PIN_HB_LED, 0);
-      sw.init();
-      power.init();
-      irda_timer.start();
-      heartbeat_led_timer.start();
+        Serial.begin(115200, SERIAL_8N1);
+        Serial1.begin(4800, SERIAL_8N1);
+        pinMode(PIN_HB_LED, OUTPUT);
+        digitalWrite(PIN_HB_LED, 0);
+        sw.init();
+        power.init();
+        irda_timer.start();
+        heartbeat_led_timer.start();
     }
     void poll() {
-      sw.poll();
-      power.poll();
-      auto sw_state{sw.get_state()};
-      if (sw_state == manual_switch::STATE::PUSHED) {
-        power.set_manual_enable(true);
-        Serial.println("Manual Charge");
-      }
-      else if (sw_state == manual_switch::STATE::LONG_PUSHED) {
-        power.set_manual_enable(false);
-        Serial.println("Auto Charge");
-      }
-      sw.set_led(power.get_manual_enable());
-      while (Serial1.available()) {
-        if (irda_timer.read_ms() > 1000)
-          msg.reset();
-        irda_timer.reset();
-        int c{Serial1.read()};
-        if (msg.decode(c)) {
-          uint8_t param[3];
-          uint8_t command{msg.get_command(param)};
-          handle_command(command, param);
+        sw.poll();
+        power.poll();
+        auto sw_state{sw.get_state()};
+        if (sw_state == manual_switch::STATE::PUSHED) {
+            power.set_manual_enable(true);
+            Serial.println("Manual Charge");
         }
-      }
-      if (heartbeat_led_timer.read_ms() > 1000) {
-        heartbeat_led_timer.reset();
-        heartbeat_led = !heartbeat_led;
-        digitalWrite(PIN_HB_LED, heartbeat_led ? 1 : 0);
-      }
-      delay(30);
+        else if (sw_state == manual_switch::STATE::LONG_PUSHED) {
+            power.set_manual_enable(false);
+            Serial.println("Auto Charge");
+        }
+        sw.set_led(power.get_manual_enable());
+        while (Serial1.available()) {
+            if (irda_timer.read_ms() > 1000)
+                msg.reset();
+            irda_timer.reset();
+            int c{Serial1.read()};
+            if (msg.decode(c)) {
+                uint8_t param[3];
+                uint8_t command{msg.get_command(param)};
+                handle_command(command, param);
+            }
+        }
+        if (heartbeat_led_timer.read_ms() > 1000) {
+            heartbeat_led_timer.reset();
+            heartbeat_led = !heartbeat_led;
+            digitalWrite(PIN_HB_LED, heartbeat_led ? 1 : 0);
+        }
+        delay(30);
     }
-  private:
+private:
     void handle_command(uint8_t command, uint8_t (&param)[3]) {
-      switch (command) {
+        switch (command) {
         case serial_message::HEARTBEAT:
-          heartbeat(param);
-          break;
+            heartbeat(param);
+            break;
         default:
-          break;
-      }
+            break;
+        }
     }
     void heartbeat(const uint8_t (&param)[3]) {
-      power.set_auto_enable(param[1] != 0, param[2]);
-      uint8_t buf[8], send_param[3] {param[0], power.get_auto_enable()};
-      serial_message::compose(buf, serial_message::HEARTBEAT, send_param);
-      Serial1.write(buf, sizeof buf);
-      power.ping();
+        power.set_auto_enable(param[1] != 0, param[2]);
+        uint8_t buf[8], send_param[3]{param[0], power.get_auto_enable()};
+        serial_message::compose(buf, serial_message::HEARTBEAT, send_param);
+        Serial1.write(buf, sizeof buf);
+        power.ping();
     }
     manual_switch sw;
     power_controller power;
@@ -481,12 +481,12 @@ namespace lexxpluss {
 
 void setup()
 {
-  impl.init();
+    impl.init();
 }
 
 void loop()
 {
-  impl.poll();
+    impl.poll();
 }
 
 }

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -227,7 +227,7 @@ public:
             timer.start();
         } else if (now == 0) {
             auto elapsed_ms{timer.read_ms()};
-            if (elapsed_ms > 5000)
+            if (elapsed_ms > 3000)
                 state = STATE::LONG_PUSHED;
             else if (elapsed_ms > 500)
                 state = STATE::PUSHED;

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -39,18 +39,56 @@ public:
     void poll() {
         if (charging) {
             if (level < 0)
-                fill_breath();  //always fill_breath during the idle state of manual charege
+                //fill_breath();
+                //always fill_breath during the idle state of manual charege
+                fill(led_blink_crossfade(led_color_manual_charging_dim, led_color_manual_charging, 3500, 10, 40, 40, 0));
             else
                 fill_charging(level);
+                last_autocharge_time_millis = millis();
         } else {
-            fill(status_color);
+//            fill(status_color);
+            int32_t t = (int32_t)millis() - (int32_t)last_autocharge_time_millis;
+            if( 0 <= t && t < 2000 ) {
+                // dim default LED color when immediately after from auto charge because of using same color.
+
+                if (t < 500){
+                    fill(CRGB::Black);
+                }
+                else {
+                    CRGB col_dim;
+                    CRGB col_def;
+                    for (int i = 0 ; i < 3 ; i ++){
+                        col_dim.raw[i] = led_color_default_dim.raw[i] * (t - 500) / 1500 ;
+                        col_def.raw[i] = led_color_default.raw[i] * (t - 500) / 1500 ;
+                    }
+//
+//                    Serial.print("col_dim: ");
+//                    Serial.print(col_dim.raw[0]);
+//                    Serial.print(", ");
+//                    Serial.print(col_dim.raw[1]);
+//                    Serial.print(", ");
+//                    Serial.print(col_dim.raw[2]);
+//                    Serial.print("    col_def: ");
+//                    Serial.print(col_def.raw[0]);
+//                    Serial.print(", ");
+//                    Serial.print(col_def.raw[1]);
+//                    Serial.print(", ");
+//                    Serial.print(col_def.raw[2]);
+//                    Serial.println(". ");
+                    
+                    fill(led_blink_crossfade(col_dim, col_def, 5000, 10, 40, 40, 0));
+                }
+            }
+            else {
+                fill(led_blink_crossfade(led_color_default_dim, led_color_default, 5000, 10, 40, 40, 0));
+            }
         }
         FastLED.show();
-        ++counter;
+//        ++counter;
     }
     void set_charging(bool enable, int32_t level = -1) {
-        if (!this->charging && enable)
-            counter = 0;
+//        if (!this->charging && enable)
+//            counter = 0;
         this->charging = enable;
         this->level = level;
     }
@@ -60,74 +98,126 @@ public:
     }
     
     const CRGB led_color_default = CRGB(12,64,8);   
-    const CRGB led_color_auto_charging = CRGB::Green;
+    const CRGB led_color_default_dim = CRGB(6,25,3);   
+    const CRGB led_color_auto_charging = CRGB(32,128,0);
+    const CRGB led_color_manual_charging = CRGB::OrangeRed;
+    const CRGB led_color_manual_charging_dim = CRGB(64,15,0);
 
 private:
     void fill(const CRGB &color) {
         for (auto &i : led)
             i = color;
     }
+    
     void fill_charging(int32_t level) {
-        static constexpr uint32_t blink_cycle_period{80}, 
-        blink_raising_period{15}, blink_lighting_period{25}, blink_falling_period{15} ;
-        //These should be : cycle > raising + lighting + falling
-        //       |--      | (not lit) 
-        //       |         \  raising_period 
-        //  cycle_period    | lit = lighting_period
-        //       |         /  falling_period
-        //       |--      | (not lit)
-        if (counter >= blink_cycle_period)
-            counter = 0;
+//        static constexpr uint32_t blink_cycle_period{80}, 
+//        blink_raising_period{15}, blink_lighting_period{25}, blink_falling_period{15} ;
+
+//        if (counter >= blink_cycle_period)
+//            counter = 0;
 
         //static const CRGB color{CRGB::OrangeRed}, black{CRGB::Black};
-        uint32_t n{NUM_LEDS * level / 100U}; // The number of LED to express current battery remaining
+        uint32_t n{(NUM_LEDS - 1) * level / 100U}; // The number of LED to express current battery remaining
 
         //blinking tip
         static constexpr uint8_t blinking_tip_length{3}; // The number of LED to blink
-        CRGB color_blinking{CRGB::Black};
-        uint32_t dim_percent{50};
-        if(counter < blink_raising_period) {
-            dim_percent = counter * 100U / blink_raising_period;
-            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
-        }
-        else if(counter < blink_raising_period + blink_lighting_period) {
-            color_blinking = led_color_auto_charging;
-        }
-        else if(counter < blink_raising_period + blink_lighting_period + blink_falling_period) {
-            dim_percent = ( (blink_raising_period + blink_lighting_period + blink_falling_period - counter) * 100U) / blink_falling_period;
-            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
-        }
-        else {
-            color_blinking = CRGB::Black;
-        }
+//        CRGB color_blinking{CRGB::Black};
+//        uint32_t dim_percent{50};
+
+
+
+        
+//        if(counter < blink_raising_period) {
+//            dim_percent = counter * 100U / blink_raising_period;
+//            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
+//        }
+//        else if(counter < blink_raising_period + blink_lighting_period) {
+//            color_blinking = led_color_auto_charging;
+//        }
+//        else if(counter < blink_raising_period + blink_lighting_period + blink_falling_period) {
+//            dim_percent = ( (blink_raising_period + blink_lighting_period + blink_falling_period - counter) * 100U) / blink_falling_period;
+//            color_blinking = CRGB(dim_percent * led_color_auto_charging.r / 100U, dim_percent * led_color_auto_charging.g / 100U, dim_percent * led_color_auto_charging.b / 100U);
+//        }
+//        else {
+//            color_blinking = CRGB::Black;
+//        }
+
+
+
+        
         for (uint32_t i{0}; i < NUM_LEDS; ++i) {
             if( i < n )
                 led[NUM_LEDS - 1 - i] = led_color_auto_charging; //#FF4500, 100%,27%,0%
-            else if (i < n + blinking_tip_length)
-                led[NUM_LEDS - 1 - i] = color_blinking;
-            else
+            else if (i < n + blinking_tip_length){
+                //led[NUM_LEDS - 1 - i] = color_blinking;
+                led[NUM_LEDS - 1 - i] = led_blink_crossfade(CRGB::Black, led_color_auto_charging, 1500, 40, 20, 20, 0);
+            }
+            else {
                 led[NUM_LEDS - 1 - i] = CRGB::Black;
+            }
         }
     }
-    void fill_breath() {
-        static constexpr uint32_t thres{60};
-        if (counter >= thres * 2)
-            counter = 0;
-        uint32_t percent;
-        if (counter < thres)
-            percent = counter * 100 / thres;
-        else
-            percent = (thres * 2 - counter) * 100 / thres;
-        CRGB color{status_color};
-        for (auto &i : color.raw)
-            i = i * percent / 100;
-        fill(color);
+//    void fill_breath() {
+//        static constexpr uint32_t thres{60};
+//        if (counter >= thres * 2)
+//            counter = 0;
+//        uint32_t percent;
+//        if (counter < thres)
+//            percent = counter * 100 / thres;
+//        else
+//            percent = (thres * 2 - counter) * 100 / thres;
+//        CRGB color{status_color};
+//        for (auto &i : color.raw)
+//            i = i * percent / 100;
+//        fill(color);
+//    }
+    CRGB led_blink_crossfade(CRGB color1, CRGB color2, int32_t period_ms, int32_t lit_percent, int32_t raising_percent, int32_t falling_percent, int32_t offset_ms){
+        /* 
+         * This is the function for changing the color of LED strip gradually. The returned color blended both color1 and color2 by calculated ratio which changing by time. 
+         * If we set black to color1 and other color to color2, the return color will be blinked. 
+         * The return value is the CRGB color
+         * period : the cycle time for each blink [counts]
+         * duty_percent : The time ratio of fully lighting vs. cycle time[0 - 100 %]
+         * raising_percent : The time ratio of raising raising slope vs. cycle time[0 - 100 %]
+         * falling_percent : The time ratio of raising falling slope vs. cycle time[0 - 100 %]
+         * offset_ms
+         * (This function can't be controlled the origin state of the color, its fully depends on the time elapsed from start up)
+        */
+        uint32_t elapsed_ms{millis() % period_ms};
+  
+        // calc color ratio
+        uint32_t color_ratio_percent{0};
+        uint32_t time_ratio_permill{elapsed_ms * 1000U / period_ms};
+        if( time_ratio_permill < raising_percent * 10U ) {  // raising (brightening) phase
+            color_ratio_percent = time_ratio_permill * 10U / raising_percent;
+        }
+        else if ( time_ratio_permill < (raising_percent + lit_percent)*10U ){ // lit phase
+            color_ratio_percent = 100U;
+        }
+        else if ( time_ratio_permill < (raising_percent + lit_percent + falling_percent)*10U ){ // falling (dimming) phase
+            color_ratio_percent = ( (raising_percent + lit_percent + falling_percent ) * 10 - time_ratio_permill) * 10U / falling_percent;
+        }
+        else {
+            color_ratio_percent = 0U;
+        }
+//        Serial.print(time_ratio_permill);
+//        Serial.print(", ");
+//        Serial.println(color_ratio_percent);
+        
+        // blend the colors
+        CRGB ret{CRGB::Black};
+        for (int i = 0; i < 3; i ++) { // 0:R, 1:G, 2:B
+            ret.raw[i] = ((int32_t)color2.raw[i] - (int32_t)color1.raw[i]) * (int32_t)color_ratio_percent / 100 + color1.raw[i];
+        }
+        return ret;
     }
     static constexpr uint32_t NUM_LEDS{45};
     CRGB led[NUM_LEDS];
     CRGB status_color{led_color_default}; //Dark Green at startup
-    uint32_t counter{0};
+//    uint32_t counter{0};
     int32_t level{0};
+    int32_t dim_led_color_percent{0};
+    unsigned long last_autocharge_time_millis{0};
     bool charging{false};
 };
 

--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -269,12 +269,12 @@ public:
             if (elapsed_ms > 10000) {
                 Serial.println("heartbeat timeout, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Blue);
+                led.set_led_status(CRGB::Black);
             }
             if (terminal.is_overheat()) {
                 Serial.println("terminal overheat, stop charging.");
                 set_auto_enable(false);
-                led.set_led_status(CRGB::Red);
+                led.set_led_status(CRGB::Black);
             }
         }
         if (relay.is_manual_mode()) {
@@ -282,7 +282,7 @@ public:
             if (elapsed_ms > 7200000) {
                 Serial.println("manual charging timeout, stop charging.");
                 set_manual_enable(false);
-                led.set_led_status(CRGB::HotPink);
+                led.set_led_status(CRGB::Black);
             }
         }
     }


### PR DESCRIPTION
### Motivation
This PR include some changes of LED behavior what is requested by customer faced teams.
* Current LED color doesn't follow the industrial standard
  * green : normal, yellow : need to care, red : error.

And also requested the changes of the time pushing the switch when turn off the manual charger was too long. This PR also include this changes.

### Behavior Changes
* changed LED color when error occured
  * Red : over heat of terminal detected

* changed LED color when auto charging
  * Blink only edge of the bar to notify it is charging

* changed LED color on default status
  * auto charge and default status are same color so it changed to other color and slight blink to make changes between them.

* Time of manual charge button push is changed

### Technical Changes
* set_led_status() is reviced as another implementation because it caused the bug (unexpected behavior) on v2.1.0
* fill_breath() is reviced to led_blink_crossfade() because some of the reason
  * fill_breath() is not managed the frequency by measured time, it has dependency to another whole code.
  * fill_breath() is only designed for manual charging so some problem occured when used it to another blinking demands.
  
### Test
* I tested on actual unit of charger, please see the [Slack](https://lexxpluss.slack.com/archives/C04S3C5GVFF/p1749199092571029?thread_ts=1748927475.601919&cid=C04S3C5GVFF)