### PR TITLE
fix(AMRSW-2112): comm_mode DE timing around heartbeat TX

### DIFF
--- a/lexxpluss_main.cpp
+++ b/lexxpluss_main.cpp
@@ -413,7 +413,9 @@ public:
         Serial.begin(115200, SERIAL_8N1);
         Serial1.begin(4800, SERIAL_8N1);
         pinMode(PIN_HB_LED, OUTPUT);
+        pinMode(PIN_COMM_MODE, OUTPUT);
         digitalWrite(PIN_HB_LED, 0);
+        digitalWrite(PIN_COMM_MODE, 0);
         sw.init();
         power.init();
         irda_timer.start();
@@ -464,7 +466,14 @@ private:
         power.set_auto_enable(param[1] != 0, param[2]);
         uint8_t buf[8], send_param[3]{param[0], power.get_auto_enable()};
         serial_message::compose(buf, serial_message::HEARTBEAT, send_param);
+
+        digitalWrite(PIN_COMM_MODE, 1);
+        delayMicroseconds(100);
         Serial1.write(buf, sizeof buf);
+        Serial1.flush();
+        delayMicroseconds(300);
+        digitalWrite(PIN_COMM_MODE, 0);
+
         power.ping();
     }
     manual_switch sw;
@@ -473,6 +482,7 @@ private:
     simpletimer irda_timer, heartbeat_led_timer;
     bool heartbeat_led{false};
     static constexpr uint8_t PIN_HB_LED{0};
+    static constexpr uint8_t PIN_COMM_MODE{1};
 } impl;
 
 }


### PR DESCRIPTION
## About
Drives the PLC transceiver DE line (`PIN_COMM_MODE`) around the charger
heartbeat send so the transceiver is in TX only while writing:

- init `comm_mode` low at boot
- assert DE → settle 100us → `Serial1.write` + `flush` → brief hold
  (300us) before deasserting back to RX

Single file (`lexxpluss_main.cpp`), +10 lines. Pairs with the SCB-side
comm_mode change (AMRSW-2112).

## Validation
Verified on v71es007 together with the SCB-side change: charger
heartbeat decodes (rx_b=8 rx_d=1), BMU charges at ~8A.
